### PR TITLE
use node-version-file with actions/setup-node@v2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,15 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: read node.js version
-        id: nodejs-version
-        run: |
-          content=`cat ./.nvmrc`
-          echo "::set-output name=content::$content"
       - uses: actions/setup-node@v2
         with:
-          # See https://github.com/actions/setup-node/issues/32
-          node-version: ${{ steps.nodejs-version.outputs.content }}
+          node-version-file: ".nvmrc"
       - run: npm install
       - uses: JS-DevTools/npm-publish@v1
         with:


### PR DESCRIPTION
actions/setup-node#338 added support for fetching the node version from a .npmrc file. This PR makes use of that.