### PR TITLE
Add prettier and format code

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,5 +1,5 @@
 {
-    "extension": ["ts"],
-    "spec": "src/**/*.test.ts",
-    "require": "ts-node/register"
-  }
+  "extension": ["ts"],
+  "spec": "src/**/*.test.ts",
+  "require": "ts-node/register"
+}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+out/
+package-lock.json
+node_modules/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "endOfLine": "lf",
+  "printWidth": 120,
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "useTabs": false
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1065,6 +1065,12 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
+    "prettier": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "dev": true
+    },
     "proxy-agent": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-5.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "compile": "tsc -b",
     "watch": "tsc -b -w",
     "test": "mocha",
-    "prepare": "npm run-script test && npm run-script compile"
+    "prepare": "npm run-script test && npm run-script compile",
+    "prettier": "prettier \"**/*.+(js|json|ts)\"",
+    "format": "npm run prettier -- --write",
+    "check-format": "npm run prettier -- --check"
   },
   "repository": {
     "type": "git",
@@ -33,6 +36,7 @@
     "@types/node": "^14.18.10",
     "@types/yauzl": "^2.9.2",
     "mocha": "^9.2.0",
+    "prettier": "^2.5.1",
     "tempy": "^1.0.1",
     "ts-node": "^9.1.1",
     "typescript": "^4.2.4"

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3,62 +3,56 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as tempy from 'tempy';
 
-
 import { Release } from './index';
 
 describe('LS installer', () => {
-	let release: Release;
+  let release: Release;
 
-	before(() => {
-		release = new Release({
-			name: 'terraform-ls',
-			version: '0.25.2',
-			shasums: 'terraform-ls_0.25.2_SHA256SUMS',
-			shasums_signature: 'terraform-ls_0.25.2_SHA256SUMS.sig',
-			shasums_signatures: [
-				'terraform-ls_0.25.2_SHA256SUMS.72D7468F.sig',
-				'terraform-ls_0.25.2_SHA256SUMS.sig',
-			],
-			builds: [
-				{
-					name: 'terraform-ls',
-					version: '0.25.2',
-					os: 'darwin',
-					arch: 'amd64',
-					filename: 'terraform-ls_0.25.2_darwin_amd64.zip',
-					url: 'https://releases.hashicorp.com/terraform-ls/0.25.2/terraform-ls_0.25.2_darwin_amd64.zip',
-				},
-			],
-		});
-	});
+  before(() => {
+    release = new Release({
+      name: 'terraform-ls',
+      version: '0.25.2',
+      shasums: 'terraform-ls_0.25.2_SHA256SUMS',
+      shasums_signature: 'terraform-ls_0.25.2_SHA256SUMS.sig',
+      shasums_signatures: ['terraform-ls_0.25.2_SHA256SUMS.72D7468F.sig', 'terraform-ls_0.25.2_SHA256SUMS.sig'],
+      builds: [
+        {
+          name: 'terraform-ls',
+          version: '0.25.2',
+          os: 'darwin',
+          arch: 'amd64',
+          filename: 'terraform-ls_0.25.2_darwin_amd64.zip',
+          url: 'https://releases.hashicorp.com/terraform-ls/0.25.2/terraform-ls_0.25.2_darwin_amd64.zip',
+        },
+      ],
+    });
+  });
 
-	it('should calculate correct file sha256 sum', async () => {
-		const expectedSum = "0314c6a66b059bde92c5ed0f11601c144cbd916eff6d1241b5b44e076e5888dc";
-		const testPath = path.resolve(__dirname, "..", "testFixture", "shasumtest.txt");
+  it('should calculate correct file sha256 sum', async () => {
+    const expectedSum = '0314c6a66b059bde92c5ed0f11601c144cbd916eff6d1241b5b44e076e5888dc';
+    const testPath = path.resolve(__dirname, '..', 'testFixture', 'shasumtest.txt');
 
-		const sum = await release.calculateFileSha256Sum(testPath);
-		assert.strictEqual(sum, expectedSum);
-	});
+    const sum = await release.calculateFileSha256Sum(testPath);
+    assert.strictEqual(sum, expectedSum);
+  });
 
-	it('should download the correct sha256 sum', async () => {
-		const expectedSum = '8629ccc47ee8d4dfe6d23efb93b293948a088a936180d07d3f2ed118f6dd64a5';
+  it('should download the correct sha256 sum', async () => {
+    const expectedSum = '8629ccc47ee8d4dfe6d23efb93b293948a088a936180d07d3f2ed118f6dd64a5';
 
-		const remoteSum = await release.downloadSha256Sum(
-			release.builds[0].filename
-		);
-		assert.strictEqual(remoteSum, expectedSum);
-	});
+    const remoteSum = await release.downloadSha256Sum(release.builds[0].filename);
+    assert.strictEqual(remoteSum, expectedSum);
+  });
 
-	it('should download the release', async () => {
-		const build = release.getBuild('darwin', 'amd64');
-		const tmpDir = tempy.directory();
-		const zipFile = path.resolve(tmpDir, `terraform-ls_v${release.version}.zip`);
+  it('should download the release', async () => {
+    const build = release.getBuild('darwin', 'amd64');
+    const tmpDir = tempy.directory();
+    const zipFile = path.resolve(tmpDir, `terraform-ls_v${release.version}.zip`);
 
-		await release.download(build.url, zipFile, 'js-releases/mocha-test');
-		await release.verify(zipFile, build.filename);
+    await release.download(build.url, zipFile, 'js-releases/mocha-test');
+    await release.verify(zipFile, build.filename);
 
-		fs.rmSync(tmpDir, {
-			recursive: true
-		});
-	}).timeout(20 * 1000) // increase timeout for file download
+    fs.rmSync(tmpDir, {
+      recursive: true,
+    });
+  }).timeout(20 * 1000); // increase timeout for file download
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,8 @@
-import axiosBase, { AxiosRequestConfig } from "axios";
-const ProxyAgent = require("proxy-agent");
+import axiosBase, { AxiosRequestConfig } from 'axios';
+const ProxyAgent = require('proxy-agent');
 
-const httpProxy = process.env["HTTP_PROXY"] || process.env["http_proxy"];
-const httpsProxy = process.env["HTTPS_PROXY"] || process.env["https_proxy"];
+const httpProxy = process.env['HTTP_PROXY'] || process.env['http_proxy'];
+const httpsProxy = process.env['HTTPS_PROXY'] || process.env['https_proxy'];
 
 let proxyConf = {};
 
@@ -16,10 +16,7 @@ if (httpProxy || httpsProxy) {
 
 const axios = axiosBase.create({ ...proxyConf });
 
-export async function request<T = any>(
-  url: string,
-  options: AxiosRequestConfig = {}
-): Promise<T> {
+export async function request<T = any>(url: string, options: AxiosRequestConfig = {}): Promise<T> {
   const result = await axios.get(url, { ...options });
   return result.data;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,12 @@
 {
-    "compilerOptions": {
-        "module": "commonjs",
-        "target": "es6",
-        "outDir": "out",
-        "rootDir": "src",
-        "sourceMap": true,
-        "declaration": true
-    },
-    "include": [
-        "src"
-    ],
-    "exclude": [
-        "node_modules",
-        "out"
-    ]
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es6",
+    "outDir": "out",
+    "rootDir": "src",
+    "sourceMap": true,
+    "declaration": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "out"]
 }


### PR DESCRIPTION
This PR adds prettier for code formatting with the configuration copied from https://github.com/hashicorp/vscode-terraform/.

I then ran `npm run format` to format all files.