### PR TITLE
Update checksum test

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -38,7 +38,7 @@ describe('LS installer', () => {
   });
 
   it('should download the correct sha256 sum', async () => {
-    const expectedSum = '8629ccc47ee8d4dfe6d23efb93b293948a088a936180d07d3f2ed118f6dd64a5';
+    const expectedSum = '19d67549c9dfa6a99916351f1c5c6a40b5062e91d216c9f305d7aaf225addd0a';
 
     const remoteSum = await release.downloadSha256Sum(release.builds[0].filename);
     assert.strictEqual(remoteSum, expectedSum);


### PR DESCRIPTION
The checksum changed, because Darwin artifacts on [releases.hashicorp.com had to be resigned and notarized](https://status.hashicorp.com/incidents/xbbwr755y78b).