### PR TITLE
Fix outdated SHA in test

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -43,7 +43,7 @@ describe('LS installer', () => {
   });
 
   it('should download the correct sha256 sum', async () => {
-    const expectedSum = '19d67549c9dfa6a99916351f1c5c6a40b5062e91d216c9f305d7aaf225addd0a';
+    const expectedSum = '516fd7722c2a0d2ca774110a26751879e3dfc0146c5ce9d5ed6d7b2ac54a7cbd';
 
     const remoteSum = await release.downloadSha256Sum(release.builds[0].filename);
     assert.strictEqual(remoteSum, expectedSum);


### PR DESCRIPTION
The SHA change is a result of macOS binaries being re-signed recently and re-published, hence resulting in a different hash.

https://discuss.hashicorp.com/t/hcsec-2023-01-hashicorp-response-to-circleci-security-alert/48842/2

New SHA matches the one available from https://releases.hashicorp.com/terraform-ls/0.25.2/terraform-ls_0.25.2_SHA256SUMS for `terraform-ls_0.25.2_darwin_amd64.zip`

This unblocks other PRs which now have all failing tests in the CI checks.
