### PR TITLE
ci: Add PR test for copyright headers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,17 @@ on:
       - main
 
 jobs:
+  copywrite:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # https://github.com/actions/checkout/releases/tag/v3.5.0
+      - name: Install copywrite
+        uses: hashicorp/setup-copywrite@v1.0.0
+      - name: Validate Header Compliance
+        run: copywrite headers --plan
+
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This is a follow-up to https://github.com/hashicorp/js-releases/pull/109 to ensure we don't introduce new files with missing copyright headers and keep the repository compliant.