### PR TITLE
github: Disable dependabot for GHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,3 @@ updates:
     schedule:
       interval: "daily"
     labels: ["dependencies"]
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    labels: ["dependencies"]


### PR DESCRIPTION
This is to avoid conflicts with our own internal tooling, which comes with an added layer of trusted/reviewed revisions.