### PR TITLE
feat: show requested version in error when none was matched

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -114,7 +114,7 @@ describe('getRelease', () => {
     }));
 
     const version = '1.2.7';
-    await expect(getRelease(name, version)).rejects.toThrow('No matching version found');
+    await expect(getRelease(name, version)).rejects.toThrow('No matching version found for constraint "1.2.7"');
   });
 
   it('should filter invalid versions', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -318,6 +318,6 @@ function matchVersion(versions: Record<string, ResponseVersion>, range: string, 
   if (version) {
     return new Release(versions[version]);
   } else {
-    throw new Error('No matching version found');
+    throw new Error(`No matching version found for constraint "${range}"`);
   }
 }


### PR DESCRIPTION
There was a [recent case](https://github.com/hashicorp/vscode-terraform/actions/runs/8628994436/job/23652228961#step:4:14) where this failed in CI for the Terraform VSCode Extension, including the version (it was a not yet released Terrraform version in that case) would've made it more obvious to why that CI job failed:

<img width="1124" alt="image" src="https://github.com/hashicorp/js-releases/assets/1112056/2a74f906-0910-4f17-b50c-8facb943ecf9">
