### PR TITLE
fix: update https-proxy-agent to v7 to resolve Node 24 DEP0169 warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "axios": "^1.7.4",
-        "https-proxy-agent": "^5.0.1",
+        "https-proxy-agent": "^7.0.6",
         "openpgp": "^5.5.0",
         "semver": "^7.3.5",
         "yauzl": "^2.10.0"
@@ -1529,14 +1529,12 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dependencies": {
-        "debug": "4"
-      },
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 14"
       }
     },
     "node_modules/aggregate-error": {
@@ -3043,15 +3041,16 @@
       "dev": true
     },
     "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
       "dependencies": {
-        "agent-base": "6",
+        "agent-base": "^7.1.2",
         "debug": "4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/hashicorp/js-releases#readme",
   "dependencies": {
     "axios": "^1.7.4",
-    "https-proxy-agent": "^5.0.1",
+    "https-proxy-agent": "^7.0.6",
     "openpgp": "^5.5.0",
     "semver": "^7.3.5",
     "yauzl": "^2.10.0"

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@
  */
 
 import axiosBase, { AxiosRequestConfig } from 'axios';
-const HttpsProxyAgent = require('https-proxy-agent');
+import { HttpsProxyAgent } from 'https-proxy-agent';
 
 const httpProxy = process.env['HTTP_PROXY'] || process.env['http_proxy'];
 const httpsProxy = process.env['HTTPS_PROXY'] || process.env['https_proxy'];


### PR DESCRIPTION
## Summary

- Updates `https-proxy-agent` from `^5.0.1` to `^7.0.6` to eliminate the `url.parse()` call that triggers `[DEP0169] DeprecationWarning` on Node 24
- Switches from `require()` to a proper ES module import for the named `HttpsProxyAgent` export (API change in v7)

## Context

`https-proxy-agent@5` internally calls `url.parse()` when constructing the agent with a proxy URL string. Node 24 elevated `url.parse()` to an application deprecation ([DEP0169](https://nodejs.org/api/deprecations.html#DEP0169)), causing noisy warnings in CI logs for consumers like `hashicorp/setup-terraform`.

Fixes hashicorp/setup-terraform#549

Assisted-by: Claude (claude-opus-4.6)